### PR TITLE
Fix naming typos and safe migration

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= content_for(:title) || "Alpha Bloh" %></title>
+    <!-- Correct project title for display in the browser tab -->
+    <title><%= content_for(:title) || "Alpha Blog" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="mobile-web-app-capable" content="yes">

--- a/app/views/pwa/manifest.json.erb
+++ b/app/views/pwa/manifest.json.erb
@@ -1,5 +1,5 @@
 {
-  "name": "AlphaBloh",
+  "name": "AlphaBlog",
   "icons": [
     {
       "src": "/icon.png",
@@ -16,7 +16,7 @@
   "start_url": "/",
   "display": "standalone",
   "scope": "/",
-  "description": "AlphaBloh.",
+  "description": "AlphaBlog.",
   "theme_color": "red",
   "background_color": "red"
 }

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,7 +6,9 @@ require "rails/all"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module AlphaBloh
+# The application module name is used throughout Rails for things like
+# autoloading.  A typo here leaks into logs and generated files.
+module AlphaBlog
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 8.0

--- a/db/migrate/20241121001235_add_description.rb
+++ b/db/migrate/20241121001235_add_description.rb
@@ -1,5 +1,9 @@
 class AddDescription < ActiveRecord::Migration[8.0]
   def change
-    add_column :articles, :description, :text
+    # Guard against running this migration on databases created after the
+    # column was added to the initial table definition.
+    unless column_exists?(:articles, :description)
+      add_column :articles, :description, :text
+    end
   end
 end


### PR DESCRIPTION
## Summary
- rename `AlphaBloh` to `AlphaBlog`
- update PWA manifest and HTML title
- guard against duplicate `description` migration

## Testing
- `bundle exec rake test` *(fails: ruby-3.3.6 is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684a5c3cd3108333ab80629f49242eab